### PR TITLE
binds: cleaner icons

### DIFF
--- a/config/binds.nix
+++ b/config/binds.nix
@@ -4,15 +4,20 @@
     binds.whichKey = {
       enable = true;
       register = {
-        "<leader>f" = "Pickers";
-        "<leader>g" = "Git";
-        "<leader>d" = "Debugger";
-        "<leader>l" = "LSP";
+        "<leader>f" = " Picker";
+        "<leader>g" = " Git";
+        "<leader>d" = " Debug";
+        "<leader>l" = " LSP";
+        "<leader>b" = " Buffer";
       };
       setupOpts = {
         preset = "classic";
         delay = 0;
-        icons.mappings = false;
+        icons = {
+          mappings = false;
+          separator = "➜";
+          group = "";
+        };
         win.border = "none";
         triggers = [
           {

--- a/config/notes/obsidian.nix
+++ b/config/notes/obsidian.nix
@@ -139,7 +139,7 @@ in
     };
 
     binds.whichKey.register = {
-      "<leader>o" = "Obsidian";
+      "<leader>o" = " Obsidian";
     };
 
     keymaps = [

--- a/config/notes/spellcheck.nix
+++ b/config/notes/spellcheck.nix
@@ -23,8 +23,8 @@ in
 {
   vim = {
     binds.whichKey.register = {
-      "<leader>c" = "Spellcheck";
-      "<leader>cl" = "Language";
+      "<leader>c" = " Spellcheck";
+      "<leader>cl" = "󰗊 Language";
     };
 
     keymaps = [


### PR DESCRIPTION
Adds icons to which-key registrations and makes the icons prettier. 

Currently some registrations are in binds.nix but others are where the registration is relevant e.g. obsidian.nix.
Should all be in binds.nix or should they be spread out?