### PR TITLE
bufferline: better pick mapping

### DIFF
--- a/config/visual.nix
+++ b/config/visual.nix
@@ -25,6 +25,7 @@
         };
       };
       mappings = {
+        pick = "<leader>b";
         cycleNext = "<tab>";
         cyclePrevious = "<S-tab>";
         moveNext = "<C-.>";


### PR DESCRIPTION
As buffer pick is the only one used have it be simply `<leader>b`

Sometimes since nvf still maps sortby they show up instead.
None of these work to unmap those binds:
```nix
mappings.sortById = "";
mappings.sortById = null;
mappings.sortById = lib.mkForce "";
mappings.sortById = "<ignore>";
```